### PR TITLE
Add the README.md to the tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md


### PR DESCRIPTION
Your README is so informative!   We should share the wealth of knowledge with the world!  Unfortunately, distutils doesn't understand the .md suffix by default so we need to add a whole new MANIFEST.in file just to get it included in the tarball.  Such is life.
