### PR TITLE
Utilize the TMPDIR environment variable for the q output files

### DIFF
--- a/q.py
+++ b/q.py
@@ -45,11 +45,11 @@ ESCAPE_SEQUENCES = ['\x1b[0m'] + ['\x1b[3%dm' % i for i in range(1, 7)]
 class Q(object):
     __doc__ = __doc__  # from the module's __doc__ above
 
-    import ast, inspect, pydoc, sys, random, re, time
+    import ast, inspect, os, pydoc, sys, random, re, time
 
     # The debugging log will go to this file; temporary files will also have
     # this path as a prefix, followed by a random number.
-    OUTPUT_PATH = '/tmp/q'
+    OUTPUT_PATH = os.path.join(os.environ.get('TMPDIR', '/tmp'), 'q')
 
     NORMAL, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN = ESCAPE_SEQUENCES
     TEXT_REPR = pydoc.TextRepr()


### PR DESCRIPTION
Some people may enjoy tailing /tmp/q but for others, /tmp is a rotten neighborhood filled with oddly named unix socket files.  Using the value of TMPDIR allows those people to specify an higher class neighborhood for their logging needs.  Even in $HOME/tmp if they feel the need to keep their log file close to them at all times.
