### PR TITLE
Set __name__ and __module__ on trace wrapper to fool introspection

### DIFF
--- a/q.py
+++ b/q.py
@@ -258,6 +258,11 @@ class Q(object):
                    self.NORMAL])
             self.writer.write(s.chunks)
             return result
+        
+        # Copy the function info to fool introspection libraries
+        wrapper.__name__ = func.__name__
+        wrapper.__module__ = func.__module__
+        
         return wrapper
 
     def __call__(self, *args):


### PR DESCRIPTION
I'm using the celery `@app.Task` decorator, and it doesn't work on functions already decorated with `@q.t`.