### PR TITLE
Allow nightly Python to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ script: make
 matrix:
   allow_failures:
     - python: "nightly"
+
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ python:
   - "pypy"
 install: make deps
 script: make
+
+matrix:
+  allow_failures:
+    - python: "nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ python:
 install: make deps
 script: make
 
+# Python nightly is currently failing because the released pep8 requires
+# getargspec which has been removed in Python 3.6, a patch is already in pep8
+# but it hasn't been released yet.
+# FIXME: Remove this line once a pep8 which includes
+#  https://github.com/PyCQA/pep8/commit/c86685a3fe0ff0b6f813d90677f67a4faf662791
 matrix:
   allow_failures:
     - python: "nightly"


### PR DESCRIPTION
It's currently failing but I haven't check why yet. All the other versions are still passing.