### PR TITLE
Use qualified name for traced functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ deps:
 	# These dependencies are only needed for development.
 	pip install pep8
 	pip install wheel
+	pip install unittest2
 
 pep8:
 	@echo === Running pep8 on files

--- a/q.py
+++ b/q.py
@@ -257,10 +257,13 @@ class Q(object):
     def trace(self, func):
         """Decorator to print out a function's arguments and return value."""
 
+        def get_func_name(func):
+            return getattr(func, "__qualname__", func.__name__)
+
         def wrapper(*args, **kwargs):
             # Print out the call to the function with its arguments.
             s = self.Stanza(self.indent)
-            s.add([self.GREEN, func.__name__, self.NORMAL, '('])
+            s.add([self.GREEN, get_func_name(func), self.NORMAL, '('])
             s.indent += 4
             sep = ''
             for arg in args:

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -166,7 +166,7 @@ class TestQBasic(unittest.TestCase):
             return msg
 
         decorated_log_bad('decorated bad message')
-        self.assertInQLog("do_nothing\\('decorated bad message'\\)")
+        self.assertInQLog("do_nothing\\((?:\n\s*)?'decorated bad message'\\)")
         self.assertInQLog("-> 'decorated bad message'")
 
     def test_q_nested_good_wrappers(self):
@@ -187,8 +187,51 @@ class TestQBasic(unittest.TestCase):
             return msg
 
         decorated_log_good('decorated good message')
-        self.assertInQLog("decorated_log_good\\('decorated good message'\\)")
+        self.assertInQLog("decorated_log_good\\((?:\n\s*)?'decorated good message'\\)")
         self.assertInQLog("-> 'decorated good message'")
+
+    @unittest.skipIf(sys.version_info < (3, 3), "requires Python 3.3+")
+    def test_q_trace_method(self):
+        import q
+        q.writer.color = False
+
+        class A(object):
+            @q
+            def run1(self, arg):
+                return arg
+
+            @staticmethod
+            @q
+            def run2(arg):
+                return arg
+
+            @classmethod
+            @q
+            def run3(cls, arg):
+                return arg
+
+        a = A()
+        a.run1('first message')
+        A.run2('second message')
+        A.run3('third message')
+
+        self.assertInQLog(".*".join([
+            "\\bA.run1\\(",
+            "'first message'\\)",
+        ]))
+        self.assertInQLog("-> 'first message'")
+
+        self.assertInQLog(".*".join([
+            "\\bA.run2\\(",
+            "'second message'\\)",
+        ]))
+        self.assertInQLog("-> 'second message'")
+
+        self.assertInQLog(".*".join([
+            "\\bA.run3\\(",
+            "'third message'\\)",
+        ]))
+        self.assertInQLog("-> 'third message'")
 
 
 unittest.main()

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -9,6 +9,9 @@ import re
 import sys
 import unittest
 
+if not hasattr(unittest, "skipIf"):
+    import unittest2 as unittest
+
 qpath = os.path.abspath(os.path.join(os.path.split(__file__)[0], '..'))
 sys.path.insert(0, qpath)
 


### PR DESCRIPTION
This is useful when debugging methods with similar names in different classes, for instance models and forms in Django which both have `clean()` and `save()` methods which may call each other. If only `clean()` is displayed, one can't know for sure if it's `Model.clean()` or `Form.clean()`. But in Python 3.3+, it's really easy to tell them apart by using `func.__qualname__` instead of `func.__name__`.

The downside is that it also makes names longer for nested functions and classes (…which is why it's sometimes useful to add `\n` in the regexps in the unit tests), but IMO it's worth it :)


