### PR TITLE
q#67: Display correct output when multiple calls are on a line

### DIFF
--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -111,6 +111,32 @@ class TestQBasic(unittest.TestCase):
             "s.attrib2='Attrib2'",
             ]))
 
+    def test_q_multiple_calls_on_line(self):
+        import q
+        q.writer.color = False
+
+        class A:
+            def __init__(self, two, three, four):
+                self.attrib1 = 'Attrib1'
+                self.attrib2 = 'Attrib2'
+                q(q(two, self.attrib1) + q(three, self.attrib2), four)
+
+        A("ArgVal1", "ArgVal2", "ArgVal3")
+        self.assertInQLog(".*".join([
+            "__init__:",
+            "two='ArgVal1',",
+            "self.attrib1='Attrib1'",
+            "__init__:",
+            "three='ArgVal2',",
+            "self.attrib2='Attrib2'",
+            "__init__:",
+            # `q(two, self.attrib1) + q(three, self.attrib2)='ArgVal1ArgVal2',`
+            # does not work despite that text being in the log, so just test
+            # for `'ArgVal1ArgVal2',`
+            "'ArgVal1ArgVal2',",
+            "four='ArgVal3'",
+            ]))
+
     def test_q_argument_order_attributes_and_arguments(self):
         import q
         q.writer.color = False
@@ -129,7 +155,7 @@ class TestQBasic(unittest.TestCase):
             "self.attrib1='Attrib1'",
             "four='ArgVal3'",
             "self.attrib2='Attrib2'",
-            ]))
+        ]))
 
     def test_q_trace(self):
         import q


### PR DESCRIPTION
Fixes #67. When there are multiple calls on a line, we need to correctly identify what call we are showing. We can accomplish this by exploiting the fact we can get the bytecode and the currently executing instruction from the caller's frame.

Our goal is to find the "call position" of the instruction within the line. For instance, in the code below:

```python
a(b(), c())
```

the b() call has call position 0, the c() call has call position 1, and the a() call has call position 2. (In short, call position is when the call will get evaluated).

We can find this by counting the number of CALL instruction between the currently executing instruction and the instruction that starts the line. Once we have the call position, we can give it to a NodeVisitor subclass, which can use that infomation to find the corresponding CALL node.

Additionally, we can no longer use the end of the line as the final offset (since there can be multiple calls on a line), so we use the call node's end_col_offset instead.